### PR TITLE
Added fix for sha3 problems in Python 3.4

### DIFF
--- a/triplesec/utils.py
+++ b/triplesec/utils.py
@@ -17,6 +17,8 @@ from collections import namedtuple
 if sys.version_info > (3, 2):
     if 'sha3_512' not in hashlib.algorithms_available:
         import sha3
+else:
+    import sha3
 
 
 MAGIC_BYTES = binascii.unhexlify(b'1c94d7de')

--- a/triplesec/utils.py
+++ b/triplesec/utils.py
@@ -14,8 +14,9 @@ import binascii
 import sys
 from six.moves import zip
 from collections import namedtuple
-if sys.version_info < (3, 4):
-    import sha3
+if sys.version_info > (3, 2):
+    if 'sha3_512' not in hashlib.algorithms_available:
+        import sha3
 
 
 MAGIC_BYTES = binascii.unhexlify(b'1c94d7de')


### PR DESCRIPTION
Simple change to enable it to check for the existence of the hash it requires and load the sha3 library if it doesn't exist.

I put the check in for Python > 3.2 as the hashlib function to list available algo's was introduced in 3.2.