### PR TITLE
Methods for use standard strings as encrypt/decrypt input/output

### DIFF
--- a/triplesec/__init__.py
+++ b/triplesec/__init__.py
@@ -90,6 +90,27 @@ class TripleSec():
         tot += sum(c.overhead_size for c in version.ciphers)
         return tot
 
+    def encrypt_ascii(self, data, key=None, v=None, extra_bytes=0,
+                      digest="hex"):
+        """
+        Encrypt data and return as ascii string. Hexadecimal digest as default.
+
+        Avaiable digests:
+            hex: Hexadecimal
+            base64: Base 64
+            hqx: hexbin4
+        """
+        digests = {"hex": binascii.b2a_hex,
+                   "base64": binascii.b2a_base64,
+                   "hqx": binascii.b2a_hqx}
+        digestor = digests.get(digest)
+        if not digestor:
+            TripleSecError(u"Digestor not supported.")
+
+        binary_result = self.encrypt(data, key, v, extra_bytes)
+        result = digestor(binary_result)
+        return result
+
     def encrypt(self, data, key=None, v=None, extra_bytes=0):
         self._check_data(data)
         self._check_key(key)
@@ -138,6 +159,26 @@ class TripleSec():
             key = cipher_keys[n]
             data = c.implementation.encrypt(data, key)
         return data
+
+    def decrypt_ascii(self, ascii_string, key=None, digest="hex"):
+        """
+        Receive ascii string and return decrypted data.
+
+        Avaiable digests:
+            hex: Hexadecimal
+            base64: Base 64
+            hqx: hexbin4
+        """
+        digests = {"hex": binascii.a2b_hex,
+                   "base64": binascii.a2b_base64,
+                   "hqx": binascii.a2b_hqx}
+        digestor = digests.get(digest)
+        if not digestor:
+            TripleSecError(u"Digestor not supported.")
+
+        binary_string = digestor(ascii_string)
+        result = self.decrypt(binary_string, key)
+        return result
 
     def decrypt(self, data, key=None):
         self._check_data(data)
@@ -223,7 +264,10 @@ class TripleSec():
 _t = TripleSec()
 encrypt = _t.encrypt
 decrypt = _t.decrypt
+encrypt_ascii = _t.encrypt_ascii
+decrypt_ascii = _t.decrypt_ascii
 extra_bytes = _t.extra_bytes
+
 
 def main():
     import argparse


### PR DESCRIPTION
## Why
I had some problems using python implementation. I could not decode data that was encoded by JavaScript (In-Browser Magical Demo) or vice-versa. 

Using binary string is not that common for python developers so I wrote some encrypt/decrypt methods that works with standard python strings.

## Usage

```
>>> import triplesec
>>> x = triplesec.encrypt_ascii(b"IT'S A YELLOW SUBMARINE", b'* password *', digest="hex")
>>> print x
1c94d7de00000003c46ab271623b085fbf89bb85d73eb16bcb151ca2ccca3324927636474107a86ac2ed86361bdfeef1b8be203a4b5595ffefb9b0d278a03a1edfe400292183698135b59799e2b2abd04567e66f9da4a9abfdac0a5153e43432b5d2623d0e87e3a4757fca9f683312d552d735b4985e0fd82581d7892e2b698d65ee1b34a204a812d3874508f325e916bc3d586d7a8cc74ffb660849c41b42bb0e8628a338bb2348586800cdc74d6a3cc0bb35cb986c1575819b086cc297da1455df5216eec372d43b3a7848800f0a9cee2d43931cbe579850ef6acafc9b03d3a37c5c4ae68772
>>> print triplesec.decrypt(x, b'* password *', digest="hex")
IT'S A YELLOW SUBMARINE
```


```
>>> from triplesec import TripleSec
>>> T = TripleSec(b'* password *')
>>> x = T.encrypt_ascii(b"IT'S A YELLOW SUBMARINE", digest="base64")
>>> print x
HJTX3gAAAANdSkGmu4+l0MvZN2nF1DFlO+zLhMK+u8u7WPDH2imZ/gaIhR64H7H1FgwodIHOd/Rnpq41nJNTcHqGkCZK+rYZgVhF64iWzmsoLjhh869pA5C+MCyC79RewMAoSfKVCwTM/OkJbC6vbo1RdB9OuvoVC+F7jXqKqT6iAA8/EUPhzwQLwb3uolU0z0UeMuUe4p0WJ6QTbMj0RHZuUN1f0ucevDG2g3pe+r0O6E/Kq7/NBesmEPGjVAAx6UzBy7s2RvUNCBLUa97R8+hJtSztf0FOEAA7zW06Kt3DD0FrcxwL
>>> print T.decrypt_ascii(x, digest="base64")
IT'S A YELLOW SUBMARINE
```