### PR TITLE
setup: updated Github link to https://

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     description = 'a Python implementation of TripleSec',
     author = 'Keybase',
     author_email = 'max@keybase.io',
-    url = 'http://github.com/keybase/python-triplesec',
+    url = 'https://github.com/keybase/python-triplesec',
     packages = ['triplesec'],
     license = 'BSD-new',
     classifiers = ['Intended Audience :: Developers',


### PR DESCRIPTION
Because http references in a crypto library is just wrong.